### PR TITLE
the logic should be inverted

### DIFF
--- a/lib/BouncyCheckbox.style.ts
+++ b/lib/BouncyCheckbox.style.ts
@@ -37,7 +37,7 @@ export const _textStyle = (
     fontSize,
     fontFamily,
     color,
-    textDecorationLine: !textDecoration && checked ? "line-through" : "none",
+    textDecorationLine: textDecoration && checked ? "line-through" : "none",
   };
 };
 


### PR DESCRIPTION
should consider text decoration only when textDecoration is set to true and checkbox is checked